### PR TITLE
fix: The confirm button now uses the bodyLarge and bodySmall text styles

### DIFF
--- a/lib/src/widget/insta_asset_picker_delegate.dart
+++ b/lib/src/widget/insta_asset_picker_delegate.dart
@@ -342,6 +342,9 @@ class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
                         ? '${textDelegate.confirm}'
                             ' (${p.selectedAssets.length}/${p.maxAssets})'
                         : textDelegate.confirm,
+                    style: p.isSelectedNotEmpty
+                        ? theme.textTheme.bodyLarge
+                        : theme.textTheme.bodySmall,
                   )
                 : _buildLoader(context, 10),
           );


### PR DESCRIPTION
The confirm button text was previously not modifiable, unlike the confirm button text in the `wechat_assets_picker` package. (See [here](https://github.com/fluttercandies/flutter_wechat_assets_picker/blob/ad286fb5d5f56f8d99d96373fa8fd643c4274e97/lib/src/delegates/asset_picker_builder_delegate.dart#L1516C13-L1516C13))