### PR TITLE
🐛 Fix the `isAppleOS` breaking change introduced from picker 8.6.0

### DIFF
--- a/lib/src/widget/insta_asset_picker_delegate.dart
+++ b/lib/src/widget/insta_asset_picker_delegate.dart
@@ -517,7 +517,7 @@ class InstaAssetPickerBuilder extends DefaultAssetPickerBuilderDelegate {
   Widget _buildListAlbums(context) {
     return Consumer<DefaultAssetPickerProvider>(
         builder: (BuildContext context, provider, __) {
-      if (isAppleOS) return pathEntityListWidget(context);
+      if (isAppleOS(context)) return pathEntityListWidget(context);
 
       // NOTE: fix position on android, quite hacky could be optimized
       return ValueListenableBuilder<bool>(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   insta_assets_crop: ^0.0.2 # custom package from image_crop
   fraction: ^5.0.0 # to show crop ratio in crop view
-  wechat_assets_picker: ^8.5.0
+  wechat_assets_picker: ^8.6.0
   provider: ^6.0.5 # match with wechat_assets_picker package
   extended_image: ^8.0.1 # match with wechat_assets_picker package
 


### PR DESCRIPTION
https://github.com/fluttercandies/flutter_wechat_assets_picker/blob/main/guides/migration_guide.md#860