### PR TITLE
🐛 fix permission issue on Android

### DIFF
--- a/lib/src/assets_picker.dart
+++ b/lib/src/assets_picker.dart
@@ -391,6 +391,12 @@ class InstaAssetPicker {
     return AssetPicker.pickAssetsWithDelegate(
       context,
       delegate: builder,
+      permissionRequestOption: PermissionRequestOption(
+        androidPermission: AndroidPermission(
+          type: requestType,
+          mediaLocation: false,
+        ),
+      ),
       useRootNavigator: useRootNavigator,
       pageRouteBuilder: pageRouteBuilder,
     );


### PR DESCRIPTION
Now WeChat accepts the `permissionRequestOption` parameter in the `AssetPick.pickAssetsWithDelegate` method.

 I'm passing the same value configured in permissionCheck; feel free to refactor.

Related issue: #41 